### PR TITLE
Add option.useScript 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ grunt.loadNpmTasks("grunt-traceur-simple");
   application. Dependending of the used ECMAScript 6 funtionality
   in the code, this runtime is needed or not.
 
+- `useScript`:
+  Set to `true` to use the --script input format of traceur. (Useful 
+  for no module-syntax). See [Traceur options for compiling](https://github.com/google/traceur-compiler/wiki/Options-for-Compiling)
+
 ## Task Calling
 
 _Run this task with the `grunt traceur` command._

--- a/tasks/grunt-traceur-simple.js
+++ b/tasks/grunt-traceur-simple.js
@@ -79,7 +79,7 @@ module.exports = function (grunt) {
             if (options.traceurOptions !== "")
                 cmd += " " + options.traceurOptions;
             cmd += " --out " + sq(f.dest);
-			cmd += options.useScript ? ' --script' : '';
+            cmd += options.useScript ? ' --script' : '';
             cmd += " " + f.src.map(function (name) { return sq(name); }).join(" ");
 
             /*  execute the Traceur shell command  */

--- a/tasks/grunt-traceur-simple.js
+++ b/tasks/grunt-traceur-simple.js
@@ -79,6 +79,7 @@ module.exports = function (grunt) {
             if (options.traceurOptions !== "")
                 cmd += " " + options.traceurOptions;
             cmd += " --out " + sq(f.dest);
+			cmd += options.useScript ? ' --script' : '';
             cmd += " " + f.src.map(function (name) { return sq(name); }).join(" ");
 
             /*  execute the Traceur shell command  */


### PR DESCRIPTION
Implementation of an option for useScript so you can call traceur with the --script input option. 
If you don't use modules, this is the preferred output-style. 
